### PR TITLE
Scaffold AI agents course repository

### DIFF
--- a/ai-agents-course/.gitignore
+++ b/ai-agents-course/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+__pycache__/
+*.pyc
+.DS_Store
+.env
+wandb/

--- a/ai-agents-course/Makefile
+++ b/ai-agents-course/Makefile
@@ -1,0 +1,12 @@
+PYTHON ?= python3
+
+.PHONY: setup run benchmark
+
+setup:
+	$(PYTHON) -m venv .venv && .venv/bin/pip install -r requirements.txt
+
+run:
+	PYTHONPATH=src $(PYTHON) -m src.cli --help
+
+benchmark:
+	PYTHONPATH=src $(PYTHON) benchmarks/run_bench.py

--- a/ai-agents-course/README.md
+++ b/ai-agents-course/README.md
@@ -1,0 +1,10 @@
+# AI Agents Course Lab (Scaffold)
+
+This repository is a scaffold for implementing agents as you progress through the AI agents course.
+
+## Quickstart
+```bash
+make setup
+make run             # runs CLI and shows help
+make benchmark       # runs placeholder benchmark harness
+```

--- a/ai-agents-course/benchmarks/__init__.py
+++ b/ai-agents-course/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark harness for the AI Agents Course."""

--- a/ai-agents-course/benchmarks/fixtures/README.md
+++ b/ai-agents-course/benchmarks/fixtures/README.md
@@ -1,0 +1,3 @@
+# Benchmark Fixtures
+
+Placeholder directory for benchmark data.

--- a/ai-agents-course/benchmarks/run_bench.py
+++ b/ai-agents-course/benchmarks/run_bench.py
@@ -1,0 +1,10 @@
+"""Placeholder benchmark harness."""
+
+
+def main() -> None:
+    """Run the placeholder benchmark."""
+    print("TODO")
+
+
+if __name__ == "__main__":
+    main()

--- a/ai-agents-course/configs/agents/ttc.yaml
+++ b/ai-agents-course/configs/agents/ttc.yaml
@@ -1,0 +1,3 @@
+# Placeholder agent config
+name: ttc-agent
+model: placeholder-model

--- a/ai-agents-course/configs/models.yaml
+++ b/ai-agents-course/configs/models.yaml
@@ -1,0 +1,4 @@
+# Model configuration stubs
+models:
+  - name: placeholder-model
+    provider: dummy

--- a/ai-agents-course/configs/tasks/toy_math.yaml
+++ b/ai-agents-course/configs/tasks/toy_math.yaml
@@ -1,0 +1,3 @@
+# Placeholder task config
+name: toy-math
+description: Simple arithmetic toy task

--- a/ai-agents-course/requirements.txt
+++ b/ai-agents-course/requirements.txt
@@ -1,0 +1,1 @@
+# Minimal requirements for the AI Agents Course

--- a/ai-agents-course/src/__init__.py
+++ b/ai-agents-course/src/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for the AI Agents Course."""

--- a/ai-agents-course/src/cli.py
+++ b/ai-agents-course/src/cli.py
@@ -1,0 +1,14 @@
+"""Command line interface for AI Agents Course."""
+import argparse
+
+
+def main() -> None:
+    """Entry point for the CLI."""
+    parser = argparse.ArgumentParser(description="AI Agents Course CLI")
+    parser.add_argument("--version", action="version", version="0.1.0")
+    parser.parse_args()
+    print("TODO")
+
+
+if __name__ == "__main__":
+    main()

--- a/ai-agents-course/src/core/__init__.py
+++ b/ai-agents-course/src/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core utilities for AI Agents Course."""

--- a/ai-agents-course/src/core/provider.py
+++ b/ai-agents-course/src/core/provider.py
@@ -1,0 +1,9 @@
+"""Placeholder model provider."""
+
+
+class DummyProvider:
+    """Stub provider that returns a TODO string."""
+
+    def generate(self, prompt: str) -> str:
+        """Return a placeholder response."""
+        return "TODO"

--- a/ai-agents-course/src/phase1_ttc_scaling/__init__.py
+++ b/ai-agents-course/src/phase1_ttc_scaling/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 1: Task-Token-Completeness scaling experiments."""

--- a/ai-agents-course/src/phase1_ttc_scaling/repeated_sampling.py
+++ b/ai-agents-course/src/phase1_ttc_scaling/repeated_sampling.py
@@ -1,0 +1,6 @@
+"""Placeholder for repeated sampling strategies."""
+
+
+def repeated_sample() -> str:
+    """Return a placeholder value."""
+    return "TODO"

--- a/ai-agents-course/src/phase2_search_openended/__init__.py
+++ b/ai-agents-course/src/phase2_search_openended/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 2: Open-ended search agents."""

--- a/ai-agents-course/src/phase2_search_openended/search_agent.py
+++ b/ai-agents-course/src/phase2_search_openended/search_agent.py
@@ -1,0 +1,6 @@
+"""Placeholder for search agent implementation."""
+
+
+def search() -> str:
+    """Return a placeholder value."""
+    return "TODO"

--- a/ai-agents-course/src/phase3_tools_planning/__init__.py
+++ b/ai-agents-course/src/phase3_tools_planning/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 3: Tools and planning agents."""

--- a/ai-agents-course/src/phase3_tools_planning/react_planner.py
+++ b/ai-agents-course/src/phase3_tools_planning/react_planner.py
@@ -1,0 +1,6 @@
+"""Placeholder for a ReAct-style planner."""
+
+
+def plan() -> str:
+    """Return a placeholder plan."""
+    return "TODO"

--- a/ai-agents-course/src/phase4_agent_frameworks/__init__.py
+++ b/ai-agents-course/src/phase4_agent_frameworks/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 4: Agent orchestration frameworks."""

--- a/ai-agents-course/src/phase4_agent_frameworks/orchestration_agent.py
+++ b/ai-agents-course/src/phase4_agent_frameworks/orchestration_agent.py
@@ -1,0 +1,6 @@
+"""Placeholder for an agent orchestration framework."""
+
+
+def orchestrate() -> str:
+    """Return a placeholder orchestration result."""
+    return "TODO"

--- a/ai-agents-course/src/phase5_multiagent/__init__.py
+++ b/ai-agents-course/src/phase5_multiagent/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 5: Multi-agent systems."""

--- a/ai-agents-course/src/phase5_multiagent/multiagent_system.py
+++ b/ai-agents-course/src/phase5_multiagent/multiagent_system.py
@@ -1,0 +1,6 @@
+"""Placeholder for a multi-agent system."""
+
+
+def run_system() -> str:
+    """Return a placeholder system response."""
+    return "TODO"


### PR DESCRIPTION
## Summary
- scaffold course repo with placeholders for phases, configs, and benchmarks
- add simple CLI and Makefile wiring basic tasks
- stub configs for models, agents, and tasks with minimal dependencies

## Testing
- `PYTHONPATH=src python -m src.cli`
- `make run`
- `make benchmark`


------
https://chatgpt.com/codex/tasks/task_e_689b4b017c9c832a809d3e98dc1f7013