### PR TITLE
Add Agentica scaffold and DeepSWE demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,57 @@
 # RL Project
 
-This repository contains reinforcement learning projects and experiments.
+This repository hosts reinforcement-learning experiments along with an
+Agentica-style scaffold for running the **DeepSWE** agent.
+
+## Repository Layout
+
+```
+agentica/
+  agents/      # agent definitions
+  envs/        # environment wrappers
+  training/    # training utilities
+  scripts/     # runnable helpers and demos
+```
+
+## Getting Started
+
+1. **Clone rLLM** (forked to your GitHub account) and enter the repo:
+   ```bash
+   git clone https://github.com/<your-username>/rllm.git && cd rllm
+   ```
+2. **Create a Python 3.10 environment** and install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. **Prepare datasets** for SWE-Bench and R2E-Gym:
+   ```bash
+   python examples/swe/prepare_swe_data.py
+   ```
+4. **Serve the DeepSWE-Preview model** via vLLM:
+   ```bash
+   export MAX_CONTEXT_LEN=65536
+   export TENSOR_PARALLEL_SIZE=8
+   VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
+       vllm serve agentica-org/DeepSWE-Preview \
+       --tensor-parallel-size $TENSOR_PARALLEL_SIZE \
+       --max-model-len $MAX_CONTEXT_LEN \
+       --hf-overrides '{"max_position_embeddings": '$MAX_CONTEXT_LEN'}' \
+       --enable_prefix_caching
+   ```
+5. **Run evaluation** on SWE-Bench-Verified:
+   ```bash
+   time python src/r2egym/agenthub/run/edit.py runagent_multiple \
+       --traj_dir "./traj" --max_workers 48 --start_idx 0 --k 500 \
+       --dataset "R2E-Gym/SWE-Bench-Verified" --split "test" \
+       --llm_name "openai/agentica-org/DeepSWE-Preview" --scaffold "r2egym" \
+       --use_fn_calling False --exp_name "deepswe-run" --temperature 1.0 \
+       --max_steps_absolute 100 --backend "docker" --condense_history False \
+       --max_reward_calc_time 1200 --max_tokens 65536
+   ```
+6. **Minimal local test** (assumes vLLM at `http://localhost:30000/v1`):
+   ```bash
+   python agentica/scripts/run_deepswe.py --dry-run
+   ```
+
+The `requirements.txt` file lists the core libraries (Torch, transformers,
+accelerate, vLLM, verl, and rLLM) needed to experiment with DeepSWE.

--- a/agentica/__init__.py
+++ b/agentica/__init__.py
@@ -1,0 +1,1 @@
+"""Agentica-style scaffold for DeepSWE experiments."""

--- a/agentica/agents/__init__.py
+++ b/agentica/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Agents package for the Agentica scaffold."""

--- a/agentica/envs/__init__.py
+++ b/agentica/envs/__init__.py
@@ -1,0 +1,1 @@
+"""Environment wrappers for Agentica."""

--- a/agentica/scripts/run_deepswe.py
+++ b/agentica/scripts/run_deepswe.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Minimal script to query a DeepSWE model served by vLLM.
+
+This script expects a vLLM server exposing an OpenAI-compatible API
+at the given ``--api-url`` (defaults to ``http://localhost:30000/v1``).
+Use ``--dry-run`` to print the request payload without sending it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Dict
+
+try:  # Lazy import so --dry-run works without optional deps
+    import requests
+except ModuleNotFoundError:  # pragma: no cover - dependency may not be installed
+    requests = None
+
+
+def build_payload(model: str, prompt: str) -> Dict[str, Any]:
+    """Construct the chat completion payload for the given prompt."""
+    return {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run DeepSWE via local vLLM")
+    parser.add_argument("--prompt", default="Hello from DeepSWE!", help="User prompt")
+    parser.add_argument(
+        "--api-url",
+        default="http://localhost:30000/v1",
+        help="Base URL of the vLLM OpenAI-compatible API",
+    )
+    parser.add_argument(
+        "--model",
+        default="agentica-org/DeepSWE-Preview",
+        help="Model name served by vLLM",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the payload without making a request",
+    )
+    args = parser.parse_args()
+
+    payload = build_payload(args.model, args.prompt)
+
+    if args.dry_run:
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    if requests is None:
+        print("The 'requests' library is required to contact the API. Install it or use --dry-run.")
+        return 1
+
+    try:
+        response = requests.post(
+            f"{args.api_url}/chat/completions", json=payload, timeout=120
+        )
+        response.raise_for_status()
+    except Exception as exc:  # pragma: no cover - best effort error reporting
+        print(f"Request failed: {exc}")
+        return 1
+
+    data = response.json()
+    message = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+    print(message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agentica/training/__init__.py
+++ b/agentica/training/__init__.py
@@ -1,0 +1,1 @@
+"""Training utilities for Agentica."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+torch
+transformers
+accelerate
+vllm
+verl
+rllm @ git+https://github.com/rllm-org/rllm


### PR DESCRIPTION
## Summary
- scaffold `agentica` package with agents, envs, training, and demo scripts
- add DeepSWE example script for querying a vLLM-served model
- document setup and dependencies for running DeepSWE experiments

## Testing
- `python agentica/scripts/run_deepswe.py --dry-run`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ac72dfabb4832a84306e8da6e8478a